### PR TITLE
Updated Swift version for better compatibility.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.7
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
I had the error `The package product 'SwiftSoup' requires minimum platform version 10.15 for the macOS platform, but this target supports 10.13`

Changing the swift package number allows for this project to work with SwiftSoup, in addition to other swift projects.